### PR TITLE
Handle setting logger level of non-present nodes

### DIFF
--- a/src/rqt_logger_level/logger_level_service_caller.py
+++ b/src/rqt_logger_level/logger_level_service_caller.py
@@ -113,7 +113,11 @@ class LoggerLevelServiceCaller(QObject):
         if self._current_levels[logger].lower() == level.lower():
             return False
 
-        service = rosservice.get_service_class_by_name(servicename)
+        try:
+            service = rosservice.get_service_class_by_name(servicename)
+        except rosservice.ROSServiceException as e:
+            qWarning('Failed to set logger level: %s' % e)
+            return False
         request = service._request_class()
         setattr(request, 'logger', logger)
         setattr(request, 'level', level)


### PR DESCRIPTION
Give a warning instead of crashing when setting levels of non-present nodes or communication issues.