### PR TITLE
Bump cmake_minimum_required to avoid deprecation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(rqt_logger_level)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED)


### PR DESCRIPTION
Noetic will be EOL very soon and it was already discussed what last changes would be worthwhile.
This was done in [Discourse](https://discourse.ros.org/t/ros-noetic-end-of-life-may-31-2025/43160/4) .
One point was the cmake_minimum_required version because <3.5 is deprecated in newer CMake version.